### PR TITLE
Support loading autoload in the extension.json

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -65,5 +65,7 @@
 		}
 	},
 
+	"load_composer_autoloader": true,
+
 	"manifest_version": 2
 }


### PR DESCRIPTION
This is because we get:

```
Class 'EDTF\EdtfFactory' not found
from /srv/mediawiki/w/extensions/WikibaseEdtf/src/WikibaseEdtf.php(51)
```