### PR TITLE
fix: import Html\Html for 1.44

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,12 +16,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - mw: 'REL1_37'
-            php: 7.4
-          - mw: 'REL1_38'
-            php: 8.0
-          - mw: 'REL1_39'
-            php: 8.0
           - mw: 'REL1_40'
             php: 8.1
           - mw: 'REL1_41'
@@ -30,6 +24,8 @@ jobs:
             php: 8.2
           - mw: 'REL1_43'
             php: 8.2
+          - mw: 'REL1_44'
+            php: 8.3
 
     runs-on: ubuntu-latest
 

--- a/extension.json
+++ b/extension.json
@@ -16,7 +16,7 @@
 	"descriptionmsg": "wbedtf-desc",
 
 	"requires": {
-		"MediaWiki": ">= 1.37.0",
+		"MediaWiki": ">= 1.40.0",
 		"extensions": {
 			"WikibaseRepository": "*"
 		}

--- a/extension.json
+++ b/extension.json
@@ -2,7 +2,7 @@
 	"name": "Wikibase EDTF",
 	"type": "wikibase",
 
-	"version": "2.1.1",
+	"version": "3.0.0",
 
 	"author": [
 		"[https://www.EntropyWins.wtf/mediawiki Jeroen De Dauw]",

--- a/src/Services/HumanizingHtmlFormatter.php
+++ b/src/Services/HumanizingHtmlFormatter.php
@@ -10,7 +10,7 @@ use EDTF\HumanizationResult;
 use EDTF\StructuredHumanizer;
 use InvalidArgumentException;
 use ValueFormatters\ValueFormatter;
-use Html;
+use MediaWiki\Html\Html;
 
 class HumanizingHtmlFormatter implements ValueFormatter {
 


### PR DESCRIPTION
Fix import MediaWiki\Html\Html for MediaWiki 1.44.

https://phabricator.wikimedia.org/T166010
https://gerrit.wikimedia.org/r/c/mediawiki/core/+/1120610/5/includes/Html/Html.php

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated extension to version 3.0.0 with raised minimum MediaWiki requirement.
  * Improved compatibility by updating continuous integration testing to support newer MediaWiki and PHP versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->